### PR TITLE
Use SonarCloud instead of private SonarQube

### DIFF
--- a/.github/workflows/deploypage.yml
+++ b/.github/workflows/deploypage.yml
@@ -13,7 +13,9 @@ jobs:
       - uses: actions/checkout@v2
       - name: Install Node Modules
         run: npm install
-      - name: SonarQube Scan
-        run: ./sonar.sh ${{ secrets.SONARQUBE_HOST }} ${{ secrets.SONARQUBE_TOKEN }} 
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarcloud-github-action@v1.5
+        with:
+          projectBaseDir: .
       - name: Deploy GitHub Page
         run: npm run deploy


### PR DESCRIPTION
SonarCloud is free and public. I want static analysis results for this repo to be publically available anyway so it's a better fit.